### PR TITLE
sendcoins amount hotfix

### DIFF
--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -67,7 +67,7 @@ int BitcoinUnits::amountDigits(int unit)
 {
     switch(unit)
     {
-    case BTC: return 8; // 21,000,000 (# digits, without commas)
+    case BTC: return 9; // 210,000,000 (# digits, without commas)
     case mBTC: return 11; // 21,000,000,000
     case uBTC: return 14; // 21,000,000,000,000
     default: return 0;


### PR DESCRIPTION
increased the maximum sendcoins amount to 999,000,000 (# digits, without commas)